### PR TITLE
Refactor auth feature for clean architecture

### DIFF
--- a/lib/features/auth/data/repository/auth_local_repository.dart
+++ b/lib/features/auth/data/repository/auth_local_repository.dart
@@ -1,0 +1,37 @@
+import '../../../../core/storage/secure_store.dart';
+import '../../domain/entity/auth_session.dart';
+import '../../domain/entity/stored_auth.dart';
+import '../../domain/repository/i_auth_local_repository.dart';
+
+class AuthLocalRepositoryImpl implements IAuthLocalRepository {
+  final SecureStore _secureStore;
+  AuthLocalRepositoryImpl(this._secureStore);
+
+  @override
+  Future<void> saveAuthSession(AuthSession session) {
+    return _secureStore.saveAuth(
+      jwtToken: session.jwtToken,
+      firebaseToken: session.firebaseToken,
+      tokenType: session.tokenType,
+      expiresIn: session.expiresIn,
+      userId: session.userId,
+      userName: session.userName,
+      userMobileNumber: session.userMobileNumber,
+      userEmail: session.userEmail,
+    );
+  }
+
+  @override
+  Future<StoredAuth?> getStoredAuth() async {
+    final jwt = await _secureStore.readToken();
+    if (jwt == null) return null;
+    final fcm = await _secureStore.readFcmToken() ?? '';
+    final phone = await _secureStore.phoneNumber() ?? '';
+    return StoredAuth(jwtToken: jwt, firebaseToken: fcm, phoneNumber: phone);
+  }
+
+  @override
+  Future<void> clear() {
+    return _secureStore.clear();
+  }
+}

--- a/lib/features/auth/domain/entity/auth_session.dart
+++ b/lib/features/auth/domain/entity/auth_session.dart
@@ -1,0 +1,21 @@
+class AuthSession {
+  final String jwtToken;
+  final String firebaseToken;
+  final String tokenType;
+  final int expiresIn;
+  final String userId;
+  final String userName;
+  final String userMobileNumber;
+  final String? userEmail;
+
+  const AuthSession({
+    required this.jwtToken,
+    required this.firebaseToken,
+    required this.tokenType,
+    required this.expiresIn,
+    required this.userId,
+    required this.userName,
+    required this.userMobileNumber,
+    this.userEmail,
+  });
+}

--- a/lib/features/auth/domain/entity/stored_auth.dart
+++ b/lib/features/auth/domain/entity/stored_auth.dart
@@ -1,0 +1,11 @@
+class StoredAuth {
+  final String jwtToken;
+  final String firebaseToken;
+  final String phoneNumber;
+
+  const StoredAuth({
+    required this.jwtToken,
+    required this.firebaseToken,
+    required this.phoneNumber,
+  });
+}

--- a/lib/features/auth/domain/repository/i_auth_local_repository.dart
+++ b/lib/features/auth/domain/repository/i_auth_local_repository.dart
@@ -1,0 +1,8 @@
+import '../entity/auth_session.dart';
+import '../entity/stored_auth.dart';
+
+abstract class IAuthLocalRepository {
+  Future<void> saveAuthSession(AuthSession session);
+  Future<StoredAuth?> getStoredAuth();
+  Future<void> clear();
+}

--- a/lib/features/auth/domain/use_case/get_stored_auth_use_case.dart
+++ b/lib/features/auth/domain/use_case/get_stored_auth_use_case.dart
@@ -1,0 +1,11 @@
+import '../entity/stored_auth.dart';
+import '../repository/i_auth_local_repository.dart';
+
+class GetStoredAuthUseCase {
+  final IAuthLocalRepository repository;
+  GetStoredAuthUseCase(this.repository);
+
+  Future<StoredAuth?> call() {
+    return repository.getStoredAuth();
+  }
+}

--- a/lib/features/auth/domain/use_case/log_out_use_case.dart
+++ b/lib/features/auth/domain/use_case/log_out_use_case.dart
@@ -1,11 +1,10 @@
-import 'package:newmotorlube/core/storage/secure_store.dart';
+import '../repository/i_auth_local_repository.dart';
 
 class LogoutUseCase {
-  final SecureStore _secureStore;
+  final IAuthLocalRepository _repository;
+  LogoutUseCase(this._repository);
 
-  LogoutUseCase(this._secureStore);
-
-  Future<void> call() async {
-    await _secureStore.clear();
+  Future<void> call() {
+    return _repository.clear();
   }
 }

--- a/lib/features/auth/domain/use_case/save_auth_session_use_case.dart
+++ b/lib/features/auth/domain/use_case/save_auth_session_use_case.dart
@@ -1,0 +1,22 @@
+import '../entity/auth_session.dart';
+import '../entity/verify_otp_result.dart';
+import '../repository/i_auth_local_repository.dart';
+
+class SaveAuthSessionUseCase {
+  final IAuthLocalRepository repository;
+  SaveAuthSessionUseCase(this.repository);
+
+  Future<void> call(VerifyOtpResult result) {
+    final session = AuthSession(
+      jwtToken: result.tokens.jwtToken,
+      firebaseToken: result.tokens.firebaseToken,
+      tokenType: result.tokens.tokenType,
+      expiresIn: result.tokens.expiresIn,
+      userId: result.user.userId,
+      userName: result.user.name ?? '',
+      userMobileNumber: result.user.mobileNo,
+      userEmail: result.user.email,
+    );
+    return repository.saveAuthSession(session);
+  }
+}

--- a/lib/features/auth/provider/auth_provider.dart
+++ b/lib/features/auth/provider/auth_provider.dart
@@ -1,14 +1,18 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:newmotorlube/core/providers/secure_storage.dart';
-import 'package:newmotorlube/features/auth/domain/use_case/is_registered_user.dart';
-import 'package:newmotorlube/features/auth/domain/use_case/log_out_use_case.dart';
 import '../../../core/providers/dio_provider.dart';
+import '../../../core/providers/secure_storage.dart';
 import '../data/data_source/auth_remote_data_source.dart';
 import '../data/data_source/i_auth_remote_data_source.dart';
+import '../data/repository/auth_local_repository.dart';
 import '../data/repository/auth_repository.dart';
+import '../domain/repository/i_auth_local_repository.dart';
 import '../domain/repository/i_auth_repository.dart';
+import '../domain/use_case/get_stored_auth_use_case.dart';
 import '../domain/use_case/get_user_info_use_case.dart';
+import '../domain/use_case/is_registered_user.dart';
+import '../domain/use_case/log_out_use_case.dart';
 import '../domain/use_case/register_user_use_case.dart';
+import '../domain/use_case/save_auth_session_use_case.dart';
 import '../domain/use_case/send_otp_use_case.dart';
 import '../domain/use_case/verify_otp_use_case.dart';
 import '../presentation/view_model/auth_state.dart';
@@ -22,14 +26,17 @@ final authRepositoryProvider = Provider<IAuthRepository>((ref) {
   return AuthRepositoryImpl(ref.read(authRemoteDataSourceProvider));
 });
 
+final authLocalRepositoryProvider = Provider<IAuthLocalRepository>((ref) {
+  return AuthLocalRepositoryImpl(ref.read(secureStoreProvider));
+});
+
 final isRegisterUseCaseProvider = Provider<IsRegisteredUserUseCase>((ref) {
   return IsRegisteredUserUseCase(ref.read(authRepositoryProvider));
 });
 
-final logoutUseCase = Provider<LogoutUseCase>((ref) {
-  return LogoutUseCase(ref.read(secureStoreProvider));
+final logoutUseCaseProvider = Provider<LogoutUseCase>((ref) {
+  return LogoutUseCase(ref.read(authLocalRepositoryProvider));
 });
-
 
 final sendOtpUseCaseProvider = Provider<SendOtpUseCase>((ref) {
   return SendOtpUseCase(ref.read(authRepositoryProvider));
@@ -47,6 +54,14 @@ final getUserInfoUseCaseProvider = Provider<GetUserInfoUseCase>((ref) {
   return GetUserInfoUseCase(ref.read(authRepositoryProvider));
 });
 
+final saveAuthSessionUseCaseProvider = Provider<SaveAuthSessionUseCase>((ref) {
+  return SaveAuthSessionUseCase(ref.read(authLocalRepositoryProvider));
+});
+
+final getStoredAuthUseCaseProvider = Provider<GetStoredAuthUseCase>((ref) {
+  return GetStoredAuthUseCase(ref.read(authLocalRepositoryProvider));
+});
+
 final authViewModelProvider = NotifierProvider<AuthViewModel, AuthState>(
-      () => AuthViewModel(),
+  () => AuthViewModel(),
 );


### PR DESCRIPTION
## Summary
- introduce local auth repository and session entities
- move token persistence to domain use cases and update providers
- simplify AuthViewModel to interact only with use cases

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a9841304948325aa55c6ae918e61ae