### PR TITLE
Make HomeCarOutlinedCard responsive

### DIFF
--- a/lib/features/user_cars/presentation/widget/user_car_home_item_card.dart
+++ b/lib/features/user_cars/presentation/widget/user_car_home_item_card.dart
@@ -49,11 +49,11 @@ class HomeCarOutlinedCard extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // IMAGE (fills its flex)
+              // IMAGE (responsive to available width)
               Hero(
                 tag: heroTag ?? ValueKey(imageUrl),
-                child: SizedBox(
-                  height: 120,
+                child: AspectRatio(
+                  aspectRatio: 16 / 9,
                   child: ImageLoader(
                     url: imageUrl,
                     placeholder: const _ImageErrorTile(),


### PR DESCRIPTION
## Summary
- adjust HomeCarOutlinedCard image to scale with available width using AspectRatio for more responsive layout

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4e7751dc8325945feab12da7a73b