### PR TITLE
Make HomeCarOutlinedCard responsive

### DIFF
--- a/lib/features/user_cars/presentation/widget/user_car_home_item_card.dart
+++ b/lib/features/user_cars/presentation/widget/user_car_home_item_card.dart
@@ -49,11 +49,11 @@ class HomeCarOutlinedCard extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              // IMAGE (fills its flex)
+              // IMAGE (responsive to available width)
               Hero(
                 tag: heroTag ?? ValueKey(imageUrl),
-                child: SizedBox(
-                  height: 120,
+                child: AspectRatio(
+                  aspectRatio: 16 / 9,
                   child: ImageLoader(
                     url: imageUrl,
                     placeholder: const _ImageErrorTile(),
@@ -63,7 +63,8 @@ class HomeCarOutlinedCard extends StatelessWidget {
               //
               // // DETAILS (fills remainder; internally kept ultra-compact)
               Padding(
-                padding: const EdgeInsets.fromLTRB(10, 8, 10, 8),
+                // Remove bottom padding so the card height hugs the content
+                padding: const EdgeInsets.fromLTRB(10, 8, 10, 0),
                 child: _DetailsCompact(
                   model: model,
                   plate: plate,
@@ -140,9 +141,16 @@ class _DetailsCompact extends StatelessWidget {
         if (onBook != null)
           Align(
             alignment: Alignment.centerRight,
-            child: OutlinedButton(onPressed:onBook,
-                child:
-                Text('Book Now'.toUpperCase())),
+            child: OutlinedButton(
+              onPressed: onBook,
+              style: OutlinedButton.styleFrom(
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                minimumSize: Size.zero,
+                tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+              ),
+              child: Text('Book Now'.toUpperCase()),
+            ),
           ),
       ],
     );


### PR DESCRIPTION
## Summary
- adjust HomeCarOutlinedCard image to scale with available width using AspectRatio for more responsive layout
- remove bottom padding and compact Book Now button to prevent extra space at card bottom

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4e7751dc8325945feab12da7a73b