### PR TITLE
Enable local network usage for Flutter debugging

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,9 +45,15 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+        <key>CADisableMinimumFrameDurationOnPhone</key>
+        <true/>
+        <key>UIApplicationSupportsIndirectInputEvents</key>
+        <true/>
+        <key>NSLocalNetworkUsageDescription</key>
+        <string>Used to connect to the Flutter debug service.</string>
+        <key>NSBonjourServices</key>
+        <array>
+                <string>_dartobservatory._tcp</string>
+        </array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- allow Flutter debug service by declaring local network usage description
- advertise Dart Observatory Bonjour service

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68bb6a9e588c8325861536a9e5603fad