### PR TITLE
Show onboarding only on first launch

### DIFF
--- a/lib/features/splash/presentation/screens/splash_screen.dart
+++ b/lib/features/splash/presentation/screens/splash_screen.dart
@@ -6,7 +6,6 @@ import 'package:newmotorlube/core/providers/global_lang_provider.dart';
 import 'package:newmotorlube/core/utils/constant.dart';
 
 import '../../../../main.dart';
-import '../../../auth/provider/auth_provider.dart';
 import '../../provider/splash_provider.dart';
 import '../view_model/splash_state.dart';
 
@@ -27,7 +26,7 @@ class _SplashScreenState extends ConsumerState<SplashScreen> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(authViewModelProvider.notifier).authenticating();
+      ref.read(splashViewModelProvider.notifier).init();
     });
   }
 

--- a/lib/features/splash/presentation/view_model/splash_view_model.dart
+++ b/lib/features/splash/presentation/view_model/splash_view_model.dart
@@ -15,7 +15,7 @@ class SplashViewModel extends Notifier<SplashState> {
 
     ref.listen<AuthState>(authViewModelProvider, (previous, next) {
       if (next is AuthenticatedState) {
-        _handleAuthenticated();
+        state = const SplashNavigateState('baseHomeScreen');
       } else if (next is UnauthenticatedState) {
         state = const SplashNavigateState('loginScreen');
       } else if (next is AuthenticationFailedState) {
@@ -23,12 +23,15 @@ class SplashViewModel extends Notifier<SplashState> {
       }
     });
 
-
     return const SplashInitial();
   }
 
-  Future<void> _handleAuthenticated() async {
+  Future<void> init() async {
     final route = await _checkOnboardingUseCase();
-    state = SplashNavigateState(route);
+    if (route == 'onBoardingScreen') {
+      state = SplashNavigateState(route);
+    } else {
+      await ref.read(authViewModelProvider.notifier).authenticating();
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Ensure onboarding runs only on first app start
- Trigger authentication only after onboarding is complete

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe54542b483259e5a3f2b5a46e286